### PR TITLE
Fix KeyError: 'brief_teams_channels' in create_team_channels command

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -128,7 +128,7 @@ default_settings_dict = {
     "board_latest": "",
     "items": {},
     "posts": {"score-board": {"id": None, "content": ""}},
-    "brief_team_channels": False,
+    "brief_teams_channels": False,
 }
 
 roll_channel = "dice-roll"

--- a/settings.json
+++ b/settings.json
@@ -236,5 +236,5 @@
             "content": "Team 1: 0\nTeam 2: 0\nTeam 3: 0\nTeam 4: 0\nTeam 5: 0\nTeam 6: 0\nTeam 7: 0"
         }
     },
-    "brief_team_channels": true
+    "brief_teams_channels": true
 }


### PR DESCRIPTION
The settings key was stored as "brief_team_channels" (singular) in settings.json and default_settings_dict, but the code referenced "brief_teams_channels" (plural) everywhere at runtime. Standardized on the plural form to match all code usage.

https://claude.ai/code/session_01KMjpyZKwS7cuhvmReDFvEB